### PR TITLE
Add gitattributes file for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Normally when using git on Windows, it automatically converts the line endings from LF to CRLF to adjust for the OS, but this breaks bash scripts in our Linux-based containers (specifically the front-end, which does use a bash script).

This `.gitattributes` file ensures that Linux line endings are enforced for `.sh` files.